### PR TITLE
Add the ActBlue provider

### DIFF
--- a/actblue/actblue.php
+++ b/actblue/actblue.php
@@ -29,6 +29,28 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'ACTBLUE_PLUGIN_VERSION', '1.0.0' );
 
 /**
+ * Defines the ActBlue host.
+ */
+define( 'ACTBLUE_HOST', 'https://secure.actblue.com' );
+
+/**
+ * Utility function for returning the correct ActBlue endpoint url based on the
+ * environment context.
+ *
+ * @param string $route The route at the ActBlue host to hit. This parameter should
+ *                      include a leading slash.
+ *
+ * @return string The fully qualified url to make a request to ActBlue.
+ */
+function actblue_get_url( $route ) {
+	if ( defined( 'ACTBLUE_ENV' ) && 'development' === ACTBLUE_ENV && defined( 'ACTBLUE_STAGING_HOST' ) ) {
+		return ACTBLUE_STAGING_HOST . $route;
+	}
+
+	return ACTBLUE_HOST . $route;
+}
+
+/**
  * The core plugin class that is used to define internationalization,
  * admin-specific hooks, and public-facing site hooks.
  */

--- a/actblue/includes/class-actblue.php
+++ b/actblue/includes/class-actblue.php
@@ -90,9 +90,16 @@ class ActBlue {
 	 *
 	 * @since  0.1.0
 	 * @access private
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/wp_oembed_add_provider/
 	 */
 	private function enable_oembed() {
-		wp_oembed_add_provider( 'https://secure.actblue.com/*', 'https://secure.actblue.com/cf/oembed' );
+		$provider_url = actblue_get_url( '/cf/oembed' );
+
+		// This first parameter indicates the string that WordPress looks for to
+		// initiate the call to the oEmbed provider. For that reason, we'll leave
+		// that pattern consistent.
+		wp_oembed_add_provider( 'https://secure.actblue.com/*', $provider_url );
 	}
 
 	/**


### PR DESCRIPTION
## What this does

This PR adds the ActBlue oEmbed provider to the list of allowed providers, via the [wp_oembed_add_provider()](https://developer.wordpress.org/reference/functions/wp_oembed_add_provider/) function.

This fixes #7.

## To test

0. Pull down this branch and start your environment (`docker-compose up -d`).
1. Log into WordPress (un/pwd: `admin` / `password`) and edit a post or a page.
2. Paste `https://secure.actblue.com/donate/actblue-1-embed` into the editor. Note that an ActBlue donation form should show up.
3. Add an embed block (you can type `/` then search for `embed`) and paste the same url into the embed field. You should again get an ActBlue donation form.

    <img width="1329" alt="Screen Shot 2020-11-17 at 2 44 17 PM" src="https://user-images.githubusercontent.com/3286676/99459900-b1c38480-28e3-11eb-961d-ee156a5235a2.png">

4. Save and visit the page. You should see two ActBlue donation forms:

    <img width="873" alt="Screen Shot 2020-11-17 at 2 47 01 PM" src="https://user-images.githubusercontent.com/3286676/99460058-0535d280-28e4-11eb-87cd-5925ebffcb4e.png">

5. In one of the forms, choose an amount and click `Continue`. Continuing as a guest, add some contact info and hit `Continue`. When you get to the payment, you should be able to use the test Visa card number `4242424242424242` to submit a test donation (@samuelcole correct me if I'm missing something here, but I just did that and it seemed to work...).
