### PR TITLE
Add script to create zip archive for WP.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+actblue.zip
+

--- a/bin/archive.sh
+++ b/bin/archive.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Create a distributable Zip archive of the plugin for upload to WP.org
+#
+# Usage:
+# ./bin/archive.sh
+#
+# Prerequisites:
+# - rsync
+# - zip
+
+# Include hidden files with globs
+shopt -s dotglob
+
+echo "Copying plugin files ..."
+rsync -rc --exclude-from="actblue/.distignore" --delete --delete-excluded actblue/ dist/
+
+echo "Creating zip file ..."
+(cd dist && zip -r ../actblue.zip ./*)
+
+echo "Cleaning up ..."
+rm -rf dist
+
+echo "Done!"


### PR DESCRIPTION
## What this does
- Adds a bash script to create the initial Zip archive of the plugin for upload to WP.org

## Steps to test
1. Run `./bin/archive.sh` from the repo root
2. Confirm that it creates `actblue.zip` in the root directory
3. Confirm that it extracts to a clean copy of the plugin without files listed in the `actblue/.distignore` file