### PR TITLE
Tested up to: 5.5.3

### DIFF
--- a/actblue-contributions/readme.txt
+++ b/actblue-contributions/readme.txt
@@ -3,7 +3,7 @@ Contributors: actblue,upstatement
 Donate link: https://secure.actblue.com/
 Tags: donate,donation,fundraising,giving,charity,nonprofit,contribute,contributions
 Requires at least: 4.5
-Tested up to: 5.5.6
+Tested up to: 5.5.3
 Requires PHP: 5.6
 Stable tag: 1.0.0
 License: GPLv2 or later


### PR DESCRIPTION
We got feedback from the WordPress review process that because 5.5.6 isn't out yet, we won't appear in search, so we need to set it to the current stable which is 5.5.3