### PR TITLE
Add transforms for the buttons block

### DIFF
--- a/actblue-contributions/blocks/custom/actblue-buttons/index.js
+++ b/actblue-contributions/blocks/custom/actblue-buttons/index.js
@@ -8,6 +8,7 @@ import { __ } from "@wordpress/i18n";
  */
 import edit from "./edit";
 import save from "./save";
+import transforms from "./transforms";
 import icon from "../../icons/actblue";
 
 export const name = "actblue/buttons";
@@ -26,4 +27,5 @@ export const settings = {
 	},
 	edit,
 	save,
+	transforms,
 };

--- a/actblue-contributions/blocks/custom/actblue-buttons/transforms.js
+++ b/actblue-contributions/blocks/custom/actblue-buttons/transforms.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from "@wordpress/blocks";
+
+/**
+ * Internal dependencies
+ */
+import { name } from "./index";
+
+const ActBlueButtonsTransforms = {
+	from: [
+		{
+			type: "block",
+			blocks: ["core/buttons"],
+			transform: (attributes, innerBlocks) => {
+				const newInnerBlocks = innerBlocks.map((block) =>
+					createBlock("actblue/button", block.attributes)
+				);
+
+				// Creates the buttons block
+				return createBlock(name, {}, newInnerBlocks);
+			},
+		},
+	],
+	to: [
+		{
+			type: "block",
+			blocks: ["core/buttons"],
+			transform: (attributes, innerBlocks) => {
+				const newInnerBlocks = innerBlocks.map((block) =>
+					createBlock("core/button", block.attributes)
+				);
+
+				return createBlock("core/buttons", attributes, newInnerBlocks);
+			},
+		},
+	],
+};
+
+export default ActBlueButtonsTransforms;


### PR DESCRIPTION
This PR adds transforms for the `ActBlue Buttons` block that allow an editor to transform a core `Buttons` block into an `ActBlue Buttons` block and vice versa. Buttons inside of the respective block will also transform to the appropriate individual button block type (so changing a core `Buttons` block into an `ActBlue Buttons` block will change all the buttons inside the block to become `ActBlue Button` blocks).

## To test

0. Pull down this branch, build the assets with `yarn --cwd actblue-contributions build`, and start the environment with `docker-compose up -d`.
1. Log into WordPress and create a new post. Add a core `Buttons` block with some buttons. Add an `ActBlue Buttons` block with some buttons. Save the post.
2. Click to activate the core `Buttons` block (you can do this by clicking anywhere around, but not on, a child button block...it should appear selected with a blue focus outline). Once selected, locate the transform button on the left of the tooltip:

    ![Screen-Shot-2020-12-02-at-10-19-14-AM](https://user-images.githubusercontent.com/3286676/100914456-f163a200-3487-11eb-9e90-7a307a55f618.png)

3. Click on the transform button and select `ActBlue Buttons`. The inner buttons should not visibly change, but you'll notice that the block icon should change to the ActBlue logo and the block description in the sidebar will indicate that you're now selecting an `ActBlue Buttons` block.

    <img width="1074" alt="Screen Shot 2020-12-02 at 10 21 22 AM" src="https://user-images.githubusercontent.com/3286676/100914602-2243d700-3488-11eb-8995-aac59f0ab418.png">

4. Click into the child blocks and confirm that they are now `ActBlue Button` blocks.

5. Try changing the button group back to a core `Buttons` block. Again, the buttons won't visibly change but their block type should go back to the core `Button` type.
