### PR TITLE
Version bump script

### DIFF
--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -2,13 +2,6 @@
 
 PARAMS=""
 
-
-
-
-echo $CURRENT_BRANCH
-
-exit
-
 show_help() {
   cat <<EOF
 Usage: ${0##*/} [options]


### PR DESCRIPTION
This PR adds a script to facilitate a version bump.

```
Usage: ./bin/bump-version.sh [options]

Bump the version across plugin files. If no version is specified,
an interactive session will prompt you for the new version.

Options:

  -h, --help      Display this help and exit
  -v, --version   Set the version to bump to
  --commit        Commit the changes locally to git once bumped
  --tag           Add a local git tag once bumped
```

This will close #42.

## To test

0. Pull down this branch. Then create a new branch for testing.
1. Run the script with no options:

    ```
    ./bin/bump-version.sh
    ```
    You should see a line outputting the current version followed by an input prompt for the version you'd like to bump to.

    <img width="636" alt="Screen Shot 2020-12-10 at 10 40 17 AM" src="https://user-images.githubusercontent.com/3286676/101815239-1da89f80-3ad4-11eb-83b9-15d3477ee8af.png">

2. Type in the new version and hit enter. Then run `git status` to see your working changes. You should see the following files with changes:

    ```
    actblue-contributions/actblue-contributions.php
    actblue-contributions/composer.json
    actblue-contributions/package.json
    actblue-contributions/readme.txt
    ```

    <img width="898" alt="Screen Shot 2020-12-10 at 10 41 46 AM" src="https://user-images.githubusercontent.com/3286676/101815752-de2e8300-3ad4-11eb-98ff-6c4d69fba16b.png">

3. Clear the changes in the working directory with `git checkout` and return to the original version. Then run the version bump script again with the `--version` flag:

    ```
    ./bin/bump-version --version 1.1.1
    ```

    Again run `git status` and confirm that the right files were updated.

## Todo

- [ ] Any automated git things, like committing the changes or tagging.