### PR TITLE
Button: can apply a refcode to contributions originating from a button

### DIFF
--- a/actblue-contributions/blocks/custom/actblue-button/edit.js
+++ b/actblue-contributions/blocks/custom/actblue-button/edit.js
@@ -15,6 +15,7 @@ import {
 	TextControl,
 	withFallbackStyles,
 	Button,
+	HorizontalRule,
 } from "@wordpress/components";
 import {
 	__experimentalUseGradient,
@@ -85,7 +86,7 @@ function ActBlueButtonEdit({
 	setAttributes,
 	className,
 }) {
-	const { borderRadius, placeholder, text, endpoint } = attributes;
+	const { borderRadius, placeholder, text, endpoint, refcode } = attributes;
 
 	const [isFetching, setIsFetching] = useState(false);
 	const [fetchMessage, setFetchMessage] = useState("");
@@ -104,7 +105,6 @@ function ActBlueButtonEdit({
 		}
 
 		setIsFetching(true);
-		setButtonText("Connecting...");
 		setFetchMessage("");
 
 		const url = `https://secure.actblue.com/cf/oembed?url=${endpoint}&format=json`;
@@ -174,6 +174,7 @@ function ActBlueButtonEdit({
 
 					<Button
 						isSecondary
+						isBusy={isFetching}
 						onClick={handleEndpointSubmit}
 						disabled={isFetching || !endpoint}
 					>
@@ -196,6 +197,19 @@ function ActBlueButtonEdit({
 							{fetchMessage}
 						</p>
 					)}
+
+					<HorizontalRule />
+
+					<TextControl
+						label="Refcode"
+						value={refcode}
+						onChange={(value) =>
+							setAttributes({
+								refcode: value,
+							})
+						}
+						help="Associate contributions made through this button with a refcode."
+					/>
 
 					{/*
 					We can add a field for an `Amount` with another text control. We can grab the

--- a/actblue-contributions/blocks/custom/actblue-button/index.js
+++ b/actblue-contributions/blocks/custom/actblue-button/index.js
@@ -61,6 +61,10 @@ const attributes = {
 		type: "string",
 	},
 
+	refcode: {
+		type: "string",
+	},
+
 	/**
 	 * Uncommend the following attribute to enable a user to attach a specific donation
 	 * amount to a button. You can then access this `amount` variable in the attributes

--- a/actblue-contributions/blocks/custom/actblue-button/save.js
+++ b/actblue-contributions/blocks/custom/actblue-button/save.js
@@ -17,14 +17,15 @@ const ActBlueButtonSave = ({ attributes }) => {
 		backgroundColor,
 		borderRadius,
 		customBackgroundColor,
-		customTextColor,
 		customGradient,
+		customTextColor,
+		endpoint,
 		gradient,
+		refcode,
 		text,
 		textColor,
 		title,
 		token,
-		endpoint,
 	} = attributes;
 
 	const textClass = getColorClassName("color", textColor);
@@ -70,6 +71,8 @@ const ActBlueButtonSave = ({ attributes }) => {
 				value={text}
 				target="_blank"
 				data-token={token}
+				data-refcode={refcode}
+				rel="noopener noreferrer"
 			/>
 		</div>
 	);

--- a/actblue-contributions/public/js/actblue-contributions.js
+++ b/actblue-contributions/public/js/actblue-contributions.js
@@ -24,7 +24,7 @@ const onDocumentReady = (callback) => {
  * @return void
  */
 const handleButtonClick = (event) => {
-	const { token } = event.currentTarget.dataset;
+	const { token, refcode } = event.currentTarget.dataset;
 
 	if (!token) {
 		console.warn(
@@ -33,7 +33,7 @@ const handleButtonClick = (event) => {
 		return;
 	}
 
-	window.actblue.requestContribution({ token });
+	window.actblue.requestContribution({ token, refcodes: { refcode } });
 	event.preventDefault();
 };
 


### PR DESCRIPTION
can apply a refcode to a button in the ActBlue Settings:

<img width="283" alt="image" src="https://user-images.githubusercontent.com/18301/102274576-1af1e400-3ef2-11eb-985d-de692ba87325.png">

refcode will be included in post params to actblue:

![image](https://user-images.githubusercontent.com/18301/102274923-a3708480-3ef2-11eb-9fb1-4e910edd7d7d.png)


