### PR TITLE
Embed Preview: do not use SandBox for previews (#64)

### DIFF
--- a/actblue-contributions/blocks/custom/actblue-embed/edit.js
+++ b/actblue-contributions/blocks/custom/actblue-embed/edit.js
@@ -85,6 +85,12 @@ class EmbedEdit extends Component {
 		}
 		const { url } = this.state;
 		const { setAttributes } = this.props;
+		if (url.indexOf("https://secure.actblue.com") !== 0) {
+			console.error(
+				"Can not use ActBlue Embed block to embed non-ActBlue urls"
+			);
+			return;
+		}
 		this.setState({ editingURL: false });
 		setAttributes({ url });
 	}

--- a/actblue-contributions/blocks/custom/actblue-embed/embed-preview.js
+++ b/actblue-contributions/blocks/custom/actblue-embed/embed-preview.js
@@ -12,7 +12,7 @@ import classnames from "classnames/dedupe";
  * WordPress dependencies
  */
 import { __ } from "@wordpress/i18n";
-import { Placeholder, SandBox } from "@wordpress/components";
+import { Placeholder } from "@wordpress/components";
 import { RichText, BlockIcon } from "@wordpress/block-editor";
 import { Component } from "@wordpress/element";
 
@@ -57,16 +57,10 @@ class EmbedPreview extends Component {
 			icon,
 			label,
 		} = this.props;
-		const { scripts } = preview;
 		const { interactive } = this.state;
 
 		const html = "photo" === type ? getPhotoHtml(preview) : preview.html;
 		const cannotPreview = false;
-		const sandboxClassnames = classnames(
-			type,
-			className,
-			"wp-block-embed__wrapper"
-		);
 
 		// Disabled because the overlay div doesn't actually have a role or functionality
 		// as far as the user is concerned. We're just catching the first click so that
@@ -74,13 +68,7 @@ class EmbedPreview extends Component {
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const embedWrapper = (
 			<div className="wp-block-embed__wrapper">
-				<SandBox
-					html={html}
-					scripts={scripts}
-					title="Embedded content from actblue.com"
-					type={sandboxClassnames}
-					onFocus={this.hideOverlay}
-				/>
+				<div dangerouslySetInnerHTML={{ __html: html }} />
 				{!interactive && (
 					<div
 						className="block-library-embed__interactive-overlay"


### PR DESCRIPTION
* Embed Preview: do not use SandBox

SandBox is meant to tightly scope embed side effects so that they can't
break the rest of the editor, but since we're already just sending an
iframe tag, we know it will be contained.

Additionally, the SandBox interferes with ActBlue's ability to discern
the hosting domain, so it will block embeds loaded from SandBoxes.

* ActBlue Embed block: reject non-actblue urls

for security maybe? since we aren't using the SandBox component